### PR TITLE
Reserved ChampMarketplace sale offers

### DIFF
--- a/.openzeppelin/polygon-mumbai.json
+++ b/.openzeppelin/polygon-mumbai.json
@@ -122,6 +122,12 @@
           },
           {
             "contract": "ChampMarketplace",
+            "label": "_reservedOffers",
+            "type": "t_mapping(t_uint64,t_address)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:97"
+          },
+          {
+            "contract": "ChampMarketplace",
             "label": "__gap",
             "type": "t_array(t_uint256)50_storage",
             "src": "../project:/contracts/layer-2/ChampMarketplace.sol:724"
@@ -219,6 +225,263 @@
             ]
           },
           "t_struct(Set)3276_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)"
+              }
+            ]
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)179_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_struct(RoleData)179_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    },
+    "dfa4d5f3e09a7b3e0ebebaaa2778da91adfc849c0271e6a2bdf5a58bf1422f73": {
+      "address": "0x36C53CD074D6934b76b70996800b1452a7Db5aE6",
+      "txHash": "0xa9ef34e3a3d70b8153924e4a4e1305b1857c2e70bd76539b9be6af23a87767b3",
+      "layout": {
+        "solcVersion": "0.8.12",
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_uint8",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "_roles",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)179_storage)",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "contract": "AccessControlEnumerableUpgradeable",
+            "label": "_roleMembers",
+            "type": "t_mapping(t_bytes32,t_struct(AddressSet)3408_storage)",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol:22"
+          },
+          {
+            "contract": "AccessControlEnumerableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol:76"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_CHAMP_TOKEN_CONTRACT",
+            "type": "t_contract(IERC20Upgradeable)825",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:69"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_NFCHAMP_CONTRACT",
+            "type": "t_contract(IERC721Upgradeable)1258",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:70"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_sales",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:83"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_options",
+            "type": "t_mapping(t_uint64,t_struct(Option)11846_storage)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:85"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_rateLimits",
+            "type": "t_mapping(t_uint64,t_mapping(t_address,t_struct(RateLimit)11856_storage))",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:87"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_optionLock",
+            "type": "t_mapping(t_address,t_struct(OptionLock)11851_storage)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:89"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_marketplacePercentFees",
+            "type": "t_uint256",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:92"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_marketplaceFeesReceiver",
+            "type": "t_address",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:94"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_reservedOffers",
+            "type": "t_mapping(t_uint64,t_address)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:97"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:714"
+          }
+        ],
+        "types": {
+          "t_contract(IERC20Upgradeable)825": {
+            "label": "contract IERC20Upgradeable"
+          },
+          "t_contract(IERC721Upgradeable)1258": {
+            "label": "contract IERC721Upgradeable"
+          },
+          "t_mapping(t_uint64,t_uint256)": {
+            "label": "mapping(uint64 => uint256)"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_uint64,t_struct(Option)11846_storage)": {
+            "label": "mapping(uint64 => struct ChampMarketplace.Option)"
+          },
+          "t_struct(Option)11846_storage": {
+            "label": "struct ChampMarketplace.Option",
+            "members": [
+              {
+                "label": "buyer",
+                "type": "t_address"
+              },
+              {
+                "label": "until",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_mapping(t_uint64,t_mapping(t_address,t_struct(RateLimit)11856_storage))": {
+            "label": "mapping(uint64 => mapping(address => struct ChampMarketplace.RateLimit))"
+          },
+          "t_mapping(t_address,t_struct(RateLimit)11856_storage)": {
+            "label": "mapping(address => struct ChampMarketplace.RateLimit)"
+          },
+          "t_struct(RateLimit)11856_storage": {
+            "label": "struct ChampMarketplace.RateLimit",
+            "members": [
+              {
+                "label": "renew",
+                "type": "t_uint8"
+              },
+              {
+                "label": "until",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_mapping(t_address,t_struct(OptionLock)11851_storage)": {
+            "label": "mapping(address => struct ChampMarketplace.OptionLock)"
+          },
+          "t_struct(OptionLock)11851_storage": {
+            "label": "struct ChampMarketplace.OptionLock",
+            "members": [
+              {
+                "label": "tokenId",
+                "type": "t_uint64"
+              },
+              {
+                "label": "until",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_mapping(t_uint64,t_address)": {
+            "label": "mapping(uint64 => address)"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_mapping(t_bytes32,t_struct(AddressSet)3408_storage)": {
+            "label": "mapping(bytes32 => struct EnumerableSetUpgradeable.AddressSet)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(AddressSet)3408_storage": {
+            "label": "struct EnumerableSetUpgradeable.AddressSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3093_storage"
+              }
+            ]
+          },
+          "t_struct(Set)3093_storage": {
             "label": "struct EnumerableSetUpgradeable.Set",
             "members": [
               {

--- a/.openzeppelin/polygon.json
+++ b/.openzeppelin/polygon.json
@@ -117,6 +117,12 @@
           },
           {
             "contract": "ChampMarketplace",
+            "label": "_reservedOffers",
+            "type": "t_mapping(t_uint64,t_address)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:97"
+          },
+          {
+            "contract": "ChampMarketplace",
             "label": "__gap",
             "type": "t_array(t_uint256)50_storage",
             "src": "../project:/contracts/layer-2/ChampMarketplace.sol:724"
@@ -214,6 +220,263 @@
             ]
           },
           "t_struct(Set)3276_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)"
+              }
+            ]
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)179_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_struct(RoleData)179_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    },
+    "dfa4d5f3e09a7b3e0ebebaaa2778da91adfc849c0271e6a2bdf5a58bf1422f73": {
+      "address": "0x66dcc8bA7cEeA269c8B6468ae74556e1f9a2E122",
+      "txHash": "0x6082eb8f37e12c014da796a8527e335ee2c927fbfaa57abfab4480abe51ca57f",
+      "layout": {
+        "solcVersion": "0.8.12",
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_uint8",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "_roles",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)179_storage)",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "contract": "AccessControlEnumerableUpgradeable",
+            "label": "_roleMembers",
+            "type": "t_mapping(t_bytes32,t_struct(AddressSet)3408_storage)",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol:22"
+          },
+          {
+            "contract": "AccessControlEnumerableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol:76"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_CHAMP_TOKEN_CONTRACT",
+            "type": "t_contract(IERC20Upgradeable)825",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:69"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_NFCHAMP_CONTRACT",
+            "type": "t_contract(IERC721Upgradeable)1258",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:70"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_sales",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:83"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_options",
+            "type": "t_mapping(t_uint64,t_struct(Option)11846_storage)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:85"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_rateLimits",
+            "type": "t_mapping(t_uint64,t_mapping(t_address,t_struct(RateLimit)11856_storage))",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:87"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_optionLock",
+            "type": "t_mapping(t_address,t_struct(OptionLock)11851_storage)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:89"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_marketplacePercentFees",
+            "type": "t_uint256",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:92"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_marketplaceFeesReceiver",
+            "type": "t_address",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:94"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_reservedOffers",
+            "type": "t_mapping(t_uint64,t_address)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:97"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:714"
+          }
+        ],
+        "types": {
+          "t_contract(IERC20Upgradeable)825": {
+            "label": "contract IERC20Upgradeable"
+          },
+          "t_contract(IERC721Upgradeable)1258": {
+            "label": "contract IERC721Upgradeable"
+          },
+          "t_mapping(t_uint64,t_uint256)": {
+            "label": "mapping(uint64 => uint256)"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_uint64,t_struct(Option)11846_storage)": {
+            "label": "mapping(uint64 => struct ChampMarketplace.Option)"
+          },
+          "t_struct(Option)11846_storage": {
+            "label": "struct ChampMarketplace.Option",
+            "members": [
+              {
+                "label": "buyer",
+                "type": "t_address"
+              },
+              {
+                "label": "until",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_mapping(t_uint64,t_mapping(t_address,t_struct(RateLimit)11856_storage))": {
+            "label": "mapping(uint64 => mapping(address => struct ChampMarketplace.RateLimit))"
+          },
+          "t_mapping(t_address,t_struct(RateLimit)11856_storage)": {
+            "label": "mapping(address => struct ChampMarketplace.RateLimit)"
+          },
+          "t_struct(RateLimit)11856_storage": {
+            "label": "struct ChampMarketplace.RateLimit",
+            "members": [
+              {
+                "label": "renew",
+                "type": "t_uint8"
+              },
+              {
+                "label": "until",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_mapping(t_address,t_struct(OptionLock)11851_storage)": {
+            "label": "mapping(address => struct ChampMarketplace.OptionLock)"
+          },
+          "t_struct(OptionLock)11851_storage": {
+            "label": "struct ChampMarketplace.OptionLock",
+            "members": [
+              {
+                "label": "tokenId",
+                "type": "t_uint64"
+              },
+              {
+                "label": "until",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_mapping(t_uint64,t_address)": {
+            "label": "mapping(uint64 => address)"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_mapping(t_bytes32,t_struct(AddressSet)3408_storage)": {
+            "label": "mapping(bytes32 => struct EnumerableSetUpgradeable.AddressSet)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(AddressSet)3408_storage": {
+            "label": "struct EnumerableSetUpgradeable.AddressSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3093_storage"
+              }
+            ]
+          },
+          "t_struct(Set)3093_storage": {
             "label": "struct EnumerableSetUpgradeable.Set",
             "members": [
               {

--- a/.openzeppelin/unknown-56.json
+++ b/.openzeppelin/unknown-56.json
@@ -117,6 +117,12 @@
           },
           {
             "contract": "ChampMarketplace",
+            "label": "_reservedOffers",
+            "type": "t_mapping(t_uint64,t_address)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:97"
+          },
+          {
+            "contract": "ChampMarketplace",
             "label": "__gap",
             "type": "t_array(t_uint256)50_storage",
             "src": "../project:/contracts/layer-2/ChampMarketplace.sol:598"
@@ -194,6 +200,263 @@
                 "type": "t_uint256"
               }
             ]
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_mapping(t_bytes32,t_struct(AddressSet)3408_storage)": {
+            "label": "mapping(bytes32 => struct EnumerableSetUpgradeable.AddressSet)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(AddressSet)3408_storage": {
+            "label": "struct EnumerableSetUpgradeable.AddressSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3093_storage"
+              }
+            ]
+          },
+          "t_struct(Set)3093_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)"
+              }
+            ]
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)179_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_struct(RoleData)179_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    },
+    "dfa4d5f3e09a7b3e0ebebaaa2778da91adfc849c0271e6a2bdf5a58bf1422f73": {
+      "address": "0x7d8F773383c4D8F75cf4D9174A04d603357aE57F",
+      "txHash": "0x0ec33992ddf895f724e5277edd7b9c18e05f13c4091e5246319bb7a398e31df6",
+      "layout": {
+        "solcVersion": "0.8.12",
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_uint8",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "_roles",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)179_storage)",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "contract": "AccessControlEnumerableUpgradeable",
+            "label": "_roleMembers",
+            "type": "t_mapping(t_bytes32,t_struct(AddressSet)3408_storage)",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol:22"
+          },
+          {
+            "contract": "AccessControlEnumerableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol:76"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_CHAMP_TOKEN_CONTRACT",
+            "type": "t_contract(IERC20Upgradeable)825",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:69"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_NFCHAMP_CONTRACT",
+            "type": "t_contract(IERC721Upgradeable)1258",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:70"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_sales",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:83"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_options",
+            "type": "t_mapping(t_uint64,t_struct(Option)11846_storage)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:85"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_rateLimits",
+            "type": "t_mapping(t_uint64,t_mapping(t_address,t_struct(RateLimit)11856_storage))",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:87"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_optionLock",
+            "type": "t_mapping(t_address,t_struct(OptionLock)11851_storage)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:89"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_marketplacePercentFees",
+            "type": "t_uint256",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:92"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_marketplaceFeesReceiver",
+            "type": "t_address",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:94"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_reservedOffers",
+            "type": "t_mapping(t_uint64,t_address)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:97"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:714"
+          }
+        ],
+        "types": {
+          "t_contract(IERC20Upgradeable)825": {
+            "label": "contract IERC20Upgradeable"
+          },
+          "t_contract(IERC721Upgradeable)1258": {
+            "label": "contract IERC721Upgradeable"
+          },
+          "t_mapping(t_uint64,t_uint256)": {
+            "label": "mapping(uint64 => uint256)"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_uint64,t_struct(Option)11846_storage)": {
+            "label": "mapping(uint64 => struct ChampMarketplace.Option)"
+          },
+          "t_struct(Option)11846_storage": {
+            "label": "struct ChampMarketplace.Option",
+            "members": [
+              {
+                "label": "buyer",
+                "type": "t_address"
+              },
+              {
+                "label": "until",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_mapping(t_uint64,t_mapping(t_address,t_struct(RateLimit)11856_storage))": {
+            "label": "mapping(uint64 => mapping(address => struct ChampMarketplace.RateLimit))"
+          },
+          "t_mapping(t_address,t_struct(RateLimit)11856_storage)": {
+            "label": "mapping(address => struct ChampMarketplace.RateLimit)"
+          },
+          "t_struct(RateLimit)11856_storage": {
+            "label": "struct ChampMarketplace.RateLimit",
+            "members": [
+              {
+                "label": "renew",
+                "type": "t_uint8"
+              },
+              {
+                "label": "until",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_mapping(t_address,t_struct(OptionLock)11851_storage)": {
+            "label": "mapping(address => struct ChampMarketplace.OptionLock)"
+          },
+          "t_struct(OptionLock)11851_storage": {
+            "label": "struct ChampMarketplace.OptionLock",
+            "members": [
+              {
+                "label": "tokenId",
+                "type": "t_uint64"
+              },
+              {
+                "label": "until",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_mapping(t_uint64,t_address)": {
+            "label": "mapping(uint64 => address)"
           },
           "t_array(t_uint256)50_storage": {
             "label": "uint256[50]"

--- a/.openzeppelin/unknown-97.json
+++ b/.openzeppelin/unknown-97.json
@@ -1,20 +1,20 @@
 {
   "manifestVersion": "3.2",
   "admin": {
-    "address": "0x4C243D2eBe83aF7C57E28F17038c2545Aa3E4492",
-    "txHash": "0xef884d52e96e1635ad7eb9362880cb50b0ad6aa7476a8b19b89fa09de1186bdc"
+    "address": "0xe391f875F8c8456BE7C52379f286E0D6256a677b",
+    "txHash": "0x0f0253722e95ac83b862fd4ba4c296ef688d60279e426dc98fd843171b233248"
   },
   "proxies": [
     {
-      "address": "0xD6867c853ab52B220e2EF60422a16227a242223c",
-      "txHash": "0xd42920c31543f17358ea05eefd9807daf2692573ba6cd380e19a23a609433ae0",
+      "address": "0xdA70b97b55007b8C324c53B5e1d26185c44440b2",
+      "txHash": "0x9d264c0b336e8398fb7a3b59d7e879ef2ce645f9b391bf50d6500a639f97f8db",
       "kind": "transparent"
     }
   ],
   "impls": {
-    "c751b7a2983a3210e2e18c61bab6c7e71e4d9a245266e781f34a0911abdab904": {
-      "address": "0x2359bA46b4da73Ed479823542B751F9972920A40",
-      "txHash": "0x4a7a1c35bed41b9d18e680a99b456b559adad4b0bf6af5f63a9916d3653c4b1b",
+    "dfa4d5f3e09a7b3e0ebebaaa2778da91adfc849c0271e6a2bdf5a58bf1422f73": {
+      "address": "0x33E82c77c40A646a10BE3716203Fa89416bCAd6c",
+      "txHash": "0x51e52a4c025df0b32d0a0cb30a3770315596ee717c01e8e28a041110d75d94a9",
       "layout": {
         "solcVersion": "0.8.12",
         "storage": [
@@ -71,55 +71,61 @@
             "contract": "ChampMarketplace",
             "label": "_CHAMP_TOKEN_CONTRACT",
             "type": "t_contract(IERC20Upgradeable)825",
-            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:63"
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:69"
           },
           {
             "contract": "ChampMarketplace",
             "label": "_NFCHAMP_CONTRACT",
             "type": "t_contract(IERC721Upgradeable)1258",
-            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:64"
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:70"
           },
           {
             "contract": "ChampMarketplace",
             "label": "_sales",
             "type": "t_mapping(t_uint64,t_uint256)",
-            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:77"
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:83"
           },
           {
             "contract": "ChampMarketplace",
             "label": "_options",
             "type": "t_mapping(t_uint64,t_struct(Option)11846_storage)",
-            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:79"
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:85"
           },
           {
             "contract": "ChampMarketplace",
             "label": "_rateLimits",
             "type": "t_mapping(t_uint64,t_mapping(t_address,t_struct(RateLimit)11856_storage))",
-            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:81"
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:87"
           },
           {
             "contract": "ChampMarketplace",
             "label": "_optionLock",
             "type": "t_mapping(t_address,t_struct(OptionLock)11851_storage)",
-            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:83"
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:89"
           },
           {
             "contract": "ChampMarketplace",
             "label": "_marketplacePercentFees",
             "type": "t_uint256",
-            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:86"
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:92"
           },
           {
             "contract": "ChampMarketplace",
             "label": "_marketplaceFeesReceiver",
             "type": "t_address",
-            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:88"
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:94"
+          },
+          {
+            "contract": "ChampMarketplace",
+            "label": "_reservedOffers",
+            "type": "t_mapping(t_uint64,t_address)",
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:97"
           },
           {
             "contract": "ChampMarketplace",
             "label": "__gap",
             "type": "t_array(t_uint256)50_storage",
-            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:598"
+            "src": "../project:/contracts/layer-2/ChampMarketplace.sol:714"
           }
         ],
         "types": {
@@ -194,6 +200,9 @@
                 "type": "t_uint256"
               }
             ]
+          },
+          "t_mapping(t_uint64,t_address)": {
+            "label": "mapping(uint64 => address)"
           },
           "t_array(t_uint256)50_storage": {
             "label": "uint256[50]"

--- a/contracts/layer-2/ChampMarketplace.sol
+++ b/contracts/layer-2/ChampMarketplace.sol
@@ -674,7 +674,7 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
         if (hasOption(nftReceiver, tokenId)) {
             _unsetOption(nftReceiver, tokenId);
         }
-        if (hasReservedOffer(nftReceiver, tokenId)) {
+        if (_reservedOffers[tokenId] != address(0)) {
             delete _reservedOffers[tokenId];
         }
 

--- a/contracts/layer-2/ChampMarketplace.sol
+++ b/contracts/layer-2/ChampMarketplace.sol
@@ -32,6 +32,11 @@ import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgrad
  * The fees is editable by FEE_MANAGER_ROLE.
  * The fee receiver is editable by FEE_MANAGER_ROLE.
  *
+ *
+ * A NFT owner also has the option to set, or unset a reserved offer on their existing NFT
+ * sales through `setReservedOffer`. This ensures only a single CHAMP holder,
+ * approved by the NFT owner, can accept the sale.
+ *
  * For off-chain payments, an option can be set on a sale.
  * Options are restricted to only one per sale at any time.
  * Options are rate limited per sale.
@@ -322,7 +327,11 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
      * @param tokenId the ID of the NFT to check for a reserved offer
      * @return true if the given address has a reserved offer on the sale, or false if no reservation is set or if the reserve is held by a different address
      */
-    function hasReservedOffer(address from, uint64 tokenId) public view returns (bool) {
+    function hasReservedOffer(address from, uint64 tokenId)
+        public
+        view
+        returns (bool)
+    {
         return _reservedOffers[tokenId] == from;
     }
 
@@ -482,7 +491,10 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
             "ChampMarketplace: An option exists on this sale"
         );
         address nftOwner = _NFCHAMP_CONTRACT.ownerOf(tokenId);
-        require(from != nftOwner, "ChampMarketplace: Can not reserve sale for token owner.");
+        require(
+            from != nftOwner,
+            "ChampMarketplace: Can not reserve sale for token owner."
+        );
         require(
             nftOwner == msg.sender ||
                 _NFCHAMP_CONTRACT.isApprovedForAll(nftOwner, msg.sender),
@@ -492,7 +504,7 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
         _reservedOffers[tokenId] = from;
 
         emit ReservedOfferSet(tokenId, from);
-    } 
+    }
 
     /**
      * Returns true if the given address is allowed to accept the sale of the given NFT.
@@ -507,7 +519,9 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
         view
         returns (bool)
     {
-        return _reservedOffers[tokenId] == address(0) ||  _reservedOffers[tokenId] == from;
+        return
+            _reservedOffers[tokenId] == address(0) ||
+            _reservedOffers[tokenId] == from;
     }
 
     /**
@@ -570,7 +584,7 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
      * @dev Unset a reserved offer for a given NFT.
      *
      * Emits a {ReservedOfferSet} event.
-     * 
+     *
      * Requirements:
      *
      * - Reserved offer must exist for the given tokenId.
@@ -672,7 +686,7 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
         if (hasOption(nftReceiver, tokenId)) {
             _unsetOption(nftReceiver, tokenId);
         }
-        if (getReservedOffer(tokenId) != address(0)) {
+        if (hasReservedOffer(nftReceiver, tokenId)) {
             _unsetReservedOffer(tokenId);
         }
 

--- a/contracts/layer-2/ChampMarketplace.sol
+++ b/contracts/layer-2/ChampMarketplace.sol
@@ -83,8 +83,6 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
     mapping(uint64 => uint256) private _sales;
     // (nft ID => Option) mapping of options
     mapping(uint64 => Option) private _options;
-    // (nft ID => address) mapping of reserved offers
-    mapping(uint64 => address) private _reservedOffers;
     // (nft ID => wallet => RateLimit) mapping of rate limit
     mapping(uint64 => mapping(address => RateLimit)) _rateLimits;
     // (wallet => Option) mapping of locks to prevent multiple options per wallet
@@ -94,6 +92,9 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
     uint256 private _marketplacePercentFees;
     // Fees receiver address
     address private _marketplaceFeesReceiver;
+
+    // (nft ID => address) mapping of reserved offers
+    mapping(uint64 => address) private _reservedOffers;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {

--- a/contracts/layer-2/ChampMarketplace.sol
+++ b/contracts/layer-2/ChampMarketplace.sol
@@ -17,16 +17,17 @@ import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgrad
  *
  * A NFT holder can create, update or delete a sale for one of his NFTs.
  * To create a sale, the NFT holder must give his approval for the ChampMarketplace
- * on the NFT he wants to sell. Alternativly, a reserved sale can also be created, meaning
- * only a specific CHAMP holder, approved by the NFT owner, can accept the sale. Then, the NFT holder
- * must call the function `createSaleFrom`. To remove the sale, the NFT holder must call the function
- * `destroySaleFrom`.
+ * on the NFT he wants to sell. Then, the NFT holder must call the function `createSaleFrom`.
+ * A reserved sale can also be created, meaning only a specific CHAMP holder, approved by
+ * the NFT owner, can accept the sale. To remove the sale, the NFT holder must call the
+ * function `destroySaleFrom`.
  *
  * A NFT holder can also update their existing sales through the `updateSaleFrom` function.
  * This function allows the NFT holder to update a given sale's price and reserved offer.
  *
  * A CHAMP holder can accept a sale if the sale is either public, or has a reserved offer
- * set for CHAMP holder. To accept a sale, the CHAMP holder must approve CHAMP tokens to
+ * set for CHAMP holder. The function `isReservationOpenFor` can be used to verify if a given CHAMP holder
+ * can accept a specifc sale. To accept a sale, the CHAMP holder must approve CHAMP tokens to
  * the ChampMarketplace address and call the function `acceptSale`.
  *
  * Once a NFT is sold, a fee (readable through `marketplacePercentFees()`)
@@ -304,7 +305,7 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
 
     /**
      * Returns true if the given address has a reserved offer on a sale of the specified NFT.
-     * If the sale has is not reserved for a specific buyer, it means that anyone can purchase the NFT.
+     * If the sale is not reserved for a specific buyer, it means that anyone can purchase the NFT.
      *
      * @param from the address to check for a reservation
      * @param tokenId the ID of the NFT to check for a reserved offer
@@ -603,7 +604,7 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
      * - NFCHAMP ID must be on sale.
      * - salePrice must match sale price.
      * - nftReceiver can interact with the sale.
-     * - nftReceiver can accept the sale.
+     * - sale reservation is open for nftReceiver.
      * - ChampMarketplace allowance must be greater than sale price.
      */
     function _acceptSale(
@@ -673,7 +674,7 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
         if (hasOption(nftReceiver, tokenId)) {
             _unsetOption(nftReceiver, tokenId);
         }
-        if (_reservedOffers[tokenId] != address(0)) {
+        if (hasReservedOffer(nftReceiver, tokenId)) {
             delete _reservedOffers[tokenId];
         }
 

--- a/contracts/layer-2/ChampMarketplace.sol
+++ b/contracts/layer-2/ChampMarketplace.sol
@@ -37,10 +37,6 @@ import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgrad
  * The fees is editable by FEE_MANAGER_ROLE.
  * The fee receiver is editable by FEE_MANAGER_ROLE.
  *
- * A NFT owner also has the option to set, or unset a reserved offer on their existing NFT
- * sales through `setReservedOffer`. This ensures only a single CHAMP holder,
- * approved by the NFT owner, can accept the sale.
- *
  * For off-chain payments, an option can be set on a sale.
  * Options are restricted to only one per sale at any time.
  * Options are rate limited per sale.

--- a/contracts/layer-2/ChampMarketplace.sol
+++ b/contracts/layer-2/ChampMarketplace.sol
@@ -222,10 +222,6 @@ contract ChampMarketplace is AccessControlEnumerableUpgradeable {
 
         delete _sales[tokenId];
 
-        if (getReservedOffer(tokenId) != address(0)) {
-            _unsetReservedOffer(tokenId);
-        }
-
         emit SaleDestroyed(tokenId, nftOwner);
     }
 

--- a/migrations/105_reserved-offers.js
+++ b/migrations/105_reserved-offers.js
@@ -1,0 +1,1 @@
+module.exports = require("../src/migrations/105_reserved-offers")(web3);

--- a/migrations/202_reserved-offers.js
+++ b/migrations/202_reserved-offers.js
@@ -1,0 +1,1 @@
+module.exports = require("../src/migrations/202_reserved-offers")(web3);

--- a/src/migrations/105_reserved-offers.ts
+++ b/src/migrations/105_reserved-offers.ts
@@ -1,0 +1,18 @@
+import { Network } from "../types";
+import {
+  prepareUpgrade
+} from "@openzeppelin/truffle-upgrades";
+const ChampMarketplace = artifacts.require("ChampMarketplace");
+
+module.exports =
+  () =>
+  async (deployer: Truffle.Deployer, network: Network) => {
+    if (network === "test") {
+      console.log("Deployment disabled for tests");
+      return;
+    }
+    const existing = await ChampMarketplace.at("0xe6bf498d187013115d432c69bc5dd9f4c062a1f9");
+    await prepareUpgrade(existing, ChampMarketplace as any, {
+      deployer: deployer as any
+    })
+  };

--- a/src/migrations/202_reserved-offers.ts
+++ b/src/migrations/202_reserved-offers.ts
@@ -1,0 +1,18 @@
+import { Network } from "../types";
+import {
+  prepareUpgrade
+} from "@openzeppelin/truffle-upgrades";
+const ChampMarketplace = artifacts.require("ChampMarketplace");
+
+module.exports =
+  () =>
+  async (deployer: Truffle.Deployer, network: Network) => {
+    if (network === "test") {
+      console.log("Deployment disabled for tests");
+      return;
+    }
+    const existing = await ChampMarketplace.at("0xFd4cb3eb2325D81B5f091447513A1312A4F57618");
+    await prepareUpgrade(existing, ChampMarketplace as any, {
+      deployer: deployer as any
+    })
+  };

--- a/test/ChampMarketplace.fees.test.ts
+++ b/test/ChampMarketplace.fees.test.ts
@@ -152,17 +152,19 @@ contract("Marketplace", (accounts) => {
           await nftContract.approve(marketContract.address, nft, {
             from: seller,
           });
-          await marketContract.createSaleFrom(seller, nft, price, {
+          await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, price, {
             from: seller,
           });
 
           // Accept the sale
-          await tokenContract.approve(
-            marketContract.address,
+          await tokenContract.approve(marketContract.address, price, {
+            from: buyer,
+          });
+          await marketContract.methods["acceptSale(uint64,uint256)"](
+            nft,
             price,
             { from: buyer }
           );
-          await marketContract.methods["acceptSale(uint64,uint256)"](nft, price, { from: buyer });
 
           // Check final state
           expect(

--- a/test/ChampMarketplace.options.test.ts
+++ b/test/ChampMarketplace.options.test.ts
@@ -12,7 +12,6 @@ const Token = artifacts.require("TestERC20");
 
 contract("Marketplace", (accounts) => {
   describe("as a user", () => {
-    const rootUser = accounts[0];
     const seller = accounts[1];
     const buyer = accounts[2];
     let nft: number;
@@ -46,7 +45,7 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract.createSaleFrom(seller, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
           from: seller,
         });
 
@@ -64,7 +63,7 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract.createSaleFrom(seller, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
           from: seller,
         });
         await marketContract.grantRole(
@@ -85,10 +84,11 @@ contract("Marketplace", (accounts) => {
       });
 
       it("Prevents the seller to edit his sale", async () => {
+        const ZeroAddress = "0x0000000000000000000000000000000000000000";
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract.createSaleFrom(seller, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
           from: seller,
         });
         await marketContract.grantRole(
@@ -98,20 +98,20 @@ contract("Marketplace", (accounts) => {
         await marketContract.setOption(buyer, nft, { from: buyer });
 
         try {
-          await marketContract.updateSaleFrom(seller, nft, 2, { from: seller });
+          await marketContract.updateSaleFrom(seller, nft, 2, ZeroAddress, { from: seller });
           assert.fail("updateSaleFrom did not throw.");
         } catch (e: any) {
           expect(e.message).to.includes("An option exists on this sale");
         }
 
-        expect((await marketContract.getSale(nft)).toNumber()).to.equals(1);
+        expect((await marketContract.getSale(nft))[0].toNumber()).to.equals(1);
       });
 
       it("Prevents the seller to destroy his sale", async () => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract.createSaleFrom(seller, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
           from: seller,
         });
         await marketContract.grantRole(
@@ -127,7 +127,7 @@ contract("Marketplace", (accounts) => {
           expect(e.message).to.includes("An option exists on this sale");
         }
 
-        expect((await marketContract.getSale(nft)).toNumber()).to.equals(1);
+        expect((await marketContract.getSale(nft))[0].toNumber()).to.equals(1);
       });
 
       it("Prevents to have multiple option at the same time", async () => {
@@ -144,7 +144,7 @@ contract("Marketplace", (accounts) => {
           await nftContract.approve(marketContract.address, tokenId, {
             from: seller,
           });
-          await marketContract.createSaleFrom(seller, tokenId, 1, {
+          await marketContract['createSaleFrom(address,uint64,uint256)'](seller, tokenId, 1, {
             from: seller,
           });
         }
@@ -171,7 +171,7 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract.createSaleFrom(seller, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
           from: seller,
         });
         await marketContract.grantRole(
@@ -181,7 +181,9 @@ contract("Marketplace", (accounts) => {
         await marketContract.setOption(buyer, nft, { from: buyer });
 
         await tokenContract.approve(marketContract.address, 1, { from: buyer });
-        await marketContract.methods["acceptSale(uint64,uint256)"](nft, 1, { from: buyer });
+        await marketContract.methods["acceptSale(uint64,uint256)"](nft, 1, {
+          from: buyer,
+        });
 
         expect(await marketContract.hasOption(buyer, nft)).to.be.false;
       });
@@ -190,7 +192,7 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract.createSaleFrom(seller, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
           from: seller,
         });
         await marketContract.grantRole(
@@ -201,12 +203,14 @@ contract("Marketplace", (accounts) => {
         await marketContract.setOption(buyer, nft, { from: buyer });
 
         await tokenContract.approve(marketContract.address, 1, { from: buyer });
-        await marketContract.methods["acceptSale(uint64,uint256)"](nft, 1, { from: buyer });
+        await marketContract.methods["acceptSale(uint64,uint256)"](nft, 1, {
+          from: buyer,
+        });
 
         await nftContract.approve(marketContract.address, nft, {
           from: buyer,
         });
-        await marketContract.createSaleFrom(buyer, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](buyer, nft, 1, {
           from: buyer,
         });
         await marketContract.setOption(buyer, nft, { from: buyer });
@@ -218,7 +222,7 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract.createSaleFrom(seller, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
           from: seller,
         });
         await marketContract.grantRole(
@@ -244,7 +248,7 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract.createSaleFrom(seller, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
           from: seller,
         });
         await marketContract.grantRole(
@@ -276,7 +280,7 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract.createSaleFrom(seller, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
           from: seller,
         });
         await marketContract.grantRole(
@@ -298,7 +302,7 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract.createSaleFrom(seller, nft, 1, {
+        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
           from: seller,
         });
         await marketContract.grantRole(
@@ -365,7 +369,7 @@ contract("Marketplace", (accounts) => {
       await nftContract.approve(marketContract.address, nft, {
         from: seller,
       });
-      await marketContract.createSaleFrom(seller, nft, 1, {
+      await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
         from: seller,
       });
       await marketContract.setOption(buyer, nft, { from: operator });

--- a/test/ChampMarketplace.test.ts
+++ b/test/ChampMarketplace.test.ts
@@ -11,7 +11,7 @@ const Token = artifacts.require("ChildChampToken");
 const ZeroAddress = "0x0000000000000000000000000000000000000000";
 
 contract("Marketplace", (accounts) => {
-  describe.only("as a user", () => {
+  describe("as a user", () => {
     const rootUser = accounts[0];
     const seller = accounts[1];
     const buyer = accounts[2];
@@ -68,10 +68,11 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        const { receipt: createSaleReceipt } =
-          await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, SALE_PRICE, {
-            from: seller,
-          });
+        const { receipt: createSaleReceipt } = await marketContract[
+          "createSaleFrom(address,uint64,uint256)"
+        ](seller, nft, SALE_PRICE, {
+          from: seller,
+        });
         const createSaleEvent = createSaleReceipt.logs.find(
           ({ event }) => event === "SaleCreated"
         );
@@ -127,9 +128,14 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, SALE_PRICE, {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          SALE_PRICE,
+          {
+            from: seller,
+          }
+        );
 
         // Accept the sale
         await tokenContract.approve(marketContract.address, SALE_PRICE, {
@@ -156,7 +162,12 @@ contract("Marketplace", (accounts) => {
     describe("Sale creation", () => {
       it("Should require market to be approve by nft owner", async () => {
         try {
-          await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, { from: seller });
+          await marketContract["createSaleFrom(address,uint64,uint256)"](
+            seller,
+            nft,
+            1,
+            { from: seller }
+          );
           assert.fail("createSaleFrom() did not throw.");
         } catch (e: any) {
           expect(e.message).to.includes(
@@ -171,9 +182,14 @@ contract("Marketplace", (accounts) => {
           from: seller,
         });
         try {
-          await marketContract['createSaleFrom(address,uint64,uint256)'](notOwner, nft, 1, {
-            from: notOwner,
-          });
+          await marketContract["createSaleFrom(address,uint64,uint256)"](
+            notOwner,
+            nft,
+            1,
+            {
+              from: notOwner,
+            }
+          );
           assert.fail("createSaleFrom() did not throw.");
         } catch (e: any) {
           expect(e.message).to.includes("Create sale of token that is not own");
@@ -186,9 +202,14 @@ contract("Marketplace", (accounts) => {
           from: seller,
         });
         try {
-          await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
-            from: notOwner,
-          });
+          await marketContract["createSaleFrom(address,uint64,uint256)"](
+            seller,
+            nft,
+            1,
+            {
+              from: notOwner,
+            }
+          );
           assert.fail("createSaleFrom() did not throw.");
         } catch (e: any) {
           expect(e.message).to.includes(
@@ -202,16 +223,26 @@ contract("Marketplace", (accounts) => {
           from: seller,
         });
         try {
-          await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, -1, {
-            from: seller,
-          });
+          await marketContract["createSaleFrom(address,uint64,uint256)"](
+            seller,
+            nft,
+            -1,
+            {
+              from: seller,
+            }
+          );
           assert.fail("createSaleFrom() did not throw.");
         } catch (e: any) {
           expect(e.message).to.includes("value out-of-bounds");
         }
 
         try {
-          await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 0, { from: seller });
+          await marketContract["createSaleFrom(address,uint64,uint256)"](
+            seller,
+            nft,
+            0,
+            { from: seller }
+          );
           assert.fail("createSaleFrom() did not throw.");
         } catch (e: any) {
           expect(e.message).to.includes("Price should be strictly positive");
@@ -222,17 +253,21 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        const { receipt: createSaleReceipt } =
-          await marketContract['createSaleFrom(address,uint64,uint256,address)'](seller, nft, 100, buyer, {
-            from: seller,
-          });
-        
+        const { receipt: createSaleReceipt } = await marketContract[
+          "createSaleFrom(address,uint64,uint256,address)"
+        ](seller, nft, 100, buyer, {
+          from: seller,
+        });
+
         const createSaleEvent = createSaleReceipt.logs.find(
           ({ event }) => event === "SaleCreated"
         );
         expect(createSaleEvent.args.reserved).to.equals(buyer);
 
-        const hasReservedOffer = await marketContract.hasReservedOffer(buyer, nft);
+        const hasReservedOffer = await marketContract.hasReservedOffer(
+          buyer,
+          nft
+        );
         const { 1: reservedOffer } = await marketContract.getSale(nft);
 
         expect(hasReservedOffer).to.be.true;
@@ -250,13 +285,24 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, INITIAL_SALE_PRICE, {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          INITIAL_SALE_PRICE,
+          {
+            from: seller,
+          }
+        );
 
-        await marketContract.updateSaleFrom(seller, nft, NEW_SALE_PRICE, reservedAddress, {
-          from: seller,
-        });
+        await marketContract.updateSaleFrom(
+          seller,
+          nft,
+          NEW_SALE_PRICE,
+          reservedAddress,
+          {
+            from: seller,
+          }
+        );
 
         await tokenContract.approve(marketContract.address, NEW_SALE_PRICE, {
           from: buyer,
@@ -293,14 +339,25 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          1,
+          {
+            from: seller,
+          }
+        );
 
         const { receipt: updateSaleReceipt } =
-          await marketContract.updateSaleFrom(seller, nft, NEW_SALE_PRICE, reservedAddress, {
-            from: seller,
-          });
+          await marketContract.updateSaleFrom(
+            seller,
+            nft,
+            NEW_SALE_PRICE,
+            reservedAddress,
+            {
+              from: seller,
+            }
+          );
         const updateSaleEvent = updateSaleReceipt.logs.find(
           ({ event }) => event === "SaleUpdated"
         );
@@ -308,7 +365,7 @@ contract("Marketplace", (accounts) => {
         expect(updateSaleEvent.args.tokenId.toNumber()).to.equals(nft);
         expect(updateSaleEvent.args.tokenWeiPrice.toNumber()).to.equals(
           NEW_SALE_PRICE
-          );
+        );
         expect(updateSaleEvent.args.reserved).to.equals(reservedAddress);
       });
 
@@ -317,9 +374,14 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          1,
+          {
+            from: seller,
+          }
+        );
 
         const notOwner = accounts[5];
         try {
@@ -337,9 +399,14 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, 1, {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          1,
+          {
+            from: seller,
+          }
+        );
 
         try {
           await marketContract.updateSaleFrom(seller, nft, -1, ZeroAddress, {
@@ -351,7 +418,9 @@ contract("Marketplace", (accounts) => {
         }
 
         try {
-          await marketContract.updateSaleFrom(seller, nft, 0, ZeroAddress, { from: seller });
+          await marketContract.updateSaleFrom(seller, nft, 0, ZeroAddress, {
+            from: seller,
+          });
           assert.fail("createSaleFrom() did not throw.");
         } catch (e: any) {
           expect(e.message).to.includes("Price should be strictly positive");
@@ -366,9 +435,14 @@ contract("Marketplace", (accounts) => {
           await nftContract.approve(marketContract.address, nft, {
             from: seller,
           });
-          await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, SALE_PRICE, {
-            from: seller,
-          });
+          await marketContract["createSaleFrom(address,uint64,uint256)"](
+            seller,
+            nft,
+            SALE_PRICE,
+            {
+              from: seller,
+            }
+          );
           try {
             await tokenContract.approve(
               marketContract.address,
@@ -392,22 +466,24 @@ contract("Marketplace", (accounts) => {
           await nftContract.approve(marketContract.address, nft, {
             from: seller,
           });
-          await marketContract['createSaleFrom(address,uint64,uint256,address)'](seller, nft, SALE_PRICE, reservedAddress, {
+          await marketContract[
+            "createSaleFrom(address,uint64,uint256,address)"
+          ](seller, nft, SALE_PRICE, reservedAddress, {
             from: seller,
           });
 
-          const isReservationOpenForBuyer = await marketContract.isReservationOpenFor(buyer, nft);
-          const isReservationOpenForReservedAddr = await marketContract.isReservationOpenFor(reservedAddress, nft);
+          const isReservationOpenForBuyer =
+            await marketContract.isReservationOpenFor(buyer, nft);
+          const isReservationOpenForReservedAddr =
+            await marketContract.isReservationOpenFor(reservedAddress, nft);
 
           expect(isReservationOpenForBuyer).to.be.false;
           expect(isReservationOpenForReservedAddr).to.be.true;
 
           try {
-            await tokenContract.approve(
-              marketContract.address,
-              SALE_PRICE,
-              { from: buyer }
-            );
+            await tokenContract.approve(marketContract.address, SALE_PRICE, {
+              from: buyer,
+            });
             await marketContract.methods["acceptSale(uint64,uint256)"](
               nft,
               SALE_PRICE,
@@ -427,9 +503,14 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, SALE_PRICE, {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          SALE_PRICE,
+          {
+            from: seller,
+          }
+        );
         const { receipt: destroySaleReceipt } =
           await marketContract.destroySaleFrom(seller, nft, { from: seller });
         const saleDestroyedEvent = destroySaleReceipt.logs.find(
@@ -444,9 +525,14 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, SALE_PRICE, {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          SALE_PRICE,
+          {
+            from: seller,
+          }
+        );
 
         try {
           await marketContract.destroySaleFrom(anyAccount, nft, {
@@ -466,9 +552,14 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, SALE_PRICE, {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          SALE_PRICE,
+          {
+            from: seller,
+          }
+        );
 
         try {
           await marketContract.destroySaleFrom(seller, nft, {
@@ -487,9 +578,14 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, SALE_PRICE, {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          SALE_PRICE,
+          {
+            from: seller,
+          }
+        );
         await marketContract.destroySaleFrom(seller, nft, { from: seller });
 
         await tokenContract.approve(marketContract.address, SALE_PRICE, {
@@ -514,14 +610,20 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256,address)'](seller, nft, SALE_PRICE, buyer, {
-          from: seller,
-        });
-
-        const { 0: salePrice, 1: reservation }= await marketContract.getSale(nft);
-        expect(salePrice.toNumber()).to.equals(
-          SALE_PRICE
+        await marketContract["createSaleFrom(address,uint64,uint256,address)"](
+          seller,
+          nft,
+          SALE_PRICE,
+          buyer,
+          {
+            from: seller,
+          }
         );
+
+        const { 0: salePrice, 1: reservation } = await marketContract.getSale(
+          nft
+        );
+        expect(salePrice.toNumber()).to.equals(SALE_PRICE);
         expect(reservation).to.equals(buyer);
       });
 
@@ -533,9 +635,14 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, "1", {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          "1",
+          {
+            from: seller,
+          }
+        );
         await nftContract.approve(
           "0x0000000000000000000000000000000000000000",
           nft,
@@ -550,9 +657,14 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, SALE_PRICE, {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          SALE_PRICE,
+          {
+            from: seller,
+          }
+        );
 
         expect(await marketContract.hasSale(nft)).to.be.true;
       });
@@ -565,9 +677,14 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: seller,
         });
-        await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, "1", {
-          from: seller,
-        });
+        await marketContract["createSaleFrom(address,uint64,uint256)"](
+          seller,
+          nft,
+          "1",
+          {
+            from: seller,
+          }
+        );
         await nftContract.approve(
           "0x0000000000000000000000000000000000000000",
           nft,
@@ -640,10 +757,11 @@ contract("Marketplace", (accounts) => {
         await nftContract.approve(marketContract.address, nft, {
           from: operator,
         });
-        const { receipt: createSaleReceipt } =
-          await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, SALE_PRICE, {
-            from: operator,
-          });
+        const { receipt: createSaleReceipt } = await marketContract[
+          "createSaleFrom(address,uint64,uint256)"
+        ](seller, nft, SALE_PRICE, {
+          from: operator,
+        });
         const createSaleEvent = createSaleReceipt.logs.find(
           ({ event }) => event === "SaleCreated"
         );
@@ -695,13 +813,24 @@ contract("Marketplace", (accounts) => {
       await nftContract.approve(marketContract.address, nft, {
         from: operator,
       });
-      await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, INITIAL_SALE_PRICE, {
-        from: operator,
-      });
-      const { receipt: updateSaleReceipt } =
-        await marketContract.updateSaleFrom(seller, nft, NEW_SALE_PRICE, reservedAddress, {
+      await marketContract["createSaleFrom(address,uint64,uint256)"](
+        seller,
+        nft,
+        INITIAL_SALE_PRICE,
+        {
           from: operator,
-        });
+        }
+      );
+      const { receipt: updateSaleReceipt } =
+        await marketContract.updateSaleFrom(
+          seller,
+          nft,
+          NEW_SALE_PRICE,
+          reservedAddress,
+          {
+            from: operator,
+          }
+        );
       const saleUpdatedEvent = updateSaleReceipt.logs.find(
         ({ event }) => event === "SaleUpdated"
       );
@@ -709,9 +838,7 @@ contract("Marketplace", (accounts) => {
       expect(saleUpdatedEvent.args.tokenWeiPrice.toNumber()).to.equals(
         NEW_SALE_PRICE
       );
-      expect(saleUpdatedEvent.args.reserved).to.equals(
-        reservedAddress
-      );
+      expect(saleUpdatedEvent.args.reserved).to.equals(reservedAddress);
 
       await tokenContract.approve(marketContract.address, NEW_SALE_PRICE, {
         from: buyer,
@@ -747,9 +874,14 @@ contract("Marketplace", (accounts) => {
       await nftContract.approve(marketContract.address, nft, {
         from: operator,
       });
-      await marketContract['createSaleFrom(address,uint64,uint256)'](seller, nft, SALE_PRICE, {
-        from: operator,
-      });
+      await marketContract["createSaleFrom(address,uint64,uint256)"](
+        seller,
+        nft,
+        SALE_PRICE,
+        {
+          from: operator,
+        }
+      );
       const { receipt: destroySaleReceipt } =
         await marketContract.destroySaleFrom(seller, nft, { from: operator });
       const saleDestroyedEvent = destroySaleReceipt.logs.find(

--- a/types/truffle-contracts/IAccessControl.d.ts
+++ b/types/truffle-contracts/IAccessControl.d.ts
@@ -71,22 +71,22 @@ export interface IAccessControlInstance extends Truffle.ContractInstance {
    */
   grantRole: {
     (
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<Truffle.TransactionResponse<AllEvents>>;
     call(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<void>;
     sendTransaction(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<string>;
     estimateGas(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<number>;
@@ -167,22 +167,22 @@ export interface IAccessControlInstance extends Truffle.ContractInstance {
      */
     grantRole: {
       (
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<Truffle.TransactionResponse<AllEvents>>;
       call(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<void>;
       sendTransaction(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<string>;
       estimateGas(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<number>;

--- a/types/truffle-contracts/IAccessControlEnumerable.d.ts
+++ b/types/truffle-contracts/IAccessControlEnumerable.d.ts
@@ -65,22 +65,22 @@ export interface IAccessControlEnumerableInstance
    */
   grantRole: {
     (
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<Truffle.TransactionResponse<AllEvents>>;
     call(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<void>;
     sendTransaction(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<string>;
     estimateGas(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<number>;
@@ -178,22 +178,22 @@ export interface IAccessControlEnumerableInstance
      */
     grantRole: {
       (
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<Truffle.TransactionResponse<AllEvents>>;
       call(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<void>;
       sendTransaction(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<string>;
       estimateGas(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<number>;

--- a/types/truffle-contracts/TestChampMarketplace.d.ts
+++ b/types/truffle-contracts/TestChampMarketplace.d.ts
@@ -104,9 +104,11 @@ export interface SaleCreated {
     tokenId: BN;
     tokenWeiPrice: BN;
     seller: string;
+    reserve: string;
     0: BN;
     1: BN;
     2: string;
+    3: string;
   };
 }
 
@@ -126,9 +128,11 @@ export interface SaleUpdated {
     tokenId: BN;
     tokenWeiPrice: BN;
     seller: string;
+    reserve: string;
     0: BN;
     1: BN;
     2: string;
+    3: string;
   };
 }
 
@@ -176,36 +180,6 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
     weiPrice: number | BN | string,
     txDetails?: Truffle.TransactionDetails
   ): Promise<{ 0: BN; 1: BN }>;
-
-  /**
-   * Allow to create a sale for a given NFCHAMP ID at a given CHAMP wei price. Emits a {SaleCreated} event. Requirements: - tokenWeiPrice should be strictly positive. - from must be the NFCHAMP owner. - msg.sender should be either the NFCHAMP owner or approved by the NFCHAMP owner. - ChampMarketplace contract should be approved for the given NFCHAMP ID. - NFCHAMP ID should not be on sale.
-   */
-  createSaleFrom: {
-    (
-      from: string,
-      tokenId: number | BN | string,
-      tokenWeiPrice: number | BN | string,
-      txDetails?: Truffle.TransactionDetails
-    ): Promise<Truffle.TransactionResponse<AllEvents>>;
-    call(
-      from: string,
-      tokenId: number | BN | string,
-      tokenWeiPrice: number | BN | string,
-      txDetails?: Truffle.TransactionDetails
-    ): Promise<void>;
-    sendTransaction(
-      from: string,
-      tokenId: number | BN | string,
-      tokenWeiPrice: number | BN | string,
-      txDetails?: Truffle.TransactionDetails
-    ): Promise<string>;
-    estimateGas(
-      from: string,
-      tokenId: number | BN | string,
-      tokenWeiPrice: number | BN | string,
-      txDetails?: Truffle.TransactionDetails
-    ): Promise<number>;
-  };
 
   /**
    * Allow to destroy a sale for a given NFCHAMP ID. Emits a {SaleDestroyed} event. Requirements: - NFCHAMP ID should be on sale. - from can interact with the sale. - from must be the NFCHAMP owner. - msg.sender should be either the NFCHAMP owner or approved by the NFCHAMP owner. - ChampMarketplace contract should be approved for the given NFCHAMP ID.
@@ -266,12 +240,12 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
   ): Promise<BN>;
 
   /**
-   * Returns the CHAMP wei price to buy a given NFCHAMP ID. If the sale does not exists, the function returns 0.
+   * Returns the CHAMP wei price to buy a given NFCHAMP ID and the address for which the sale is reserved. If the returned address is the 0 address, that means the sale is public. If the sale does not exists, the function returns a wei price of 0.
    */
   getSale(
     tokenId: number | BN | string,
     txDetails?: Truffle.TransactionDetails
-  ): Promise<BN>;
+  ): Promise<{ 0: BN; 1: string }>;
 
   /**
    * Grants `role` to `account`. If `account` had not been already granted `role`, emits a {RoleGranted} event. Requirements: - the caller must have ``role``'s admin role. May emit a {RoleGranted} event.
@@ -305,6 +279,17 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
    * @param tokenId the ID of the NFT to check for an option
    */
   hasOption(
+    from: string,
+    tokenId: number | BN | string,
+    txDetails?: Truffle.TransactionDetails
+  ): Promise<boolean>;
+
+  /**
+   * Returns true if the given address has a reserved offer on a sale of the specified NFT. If the sale is not reserved for a specific buyer, it means that anyone can purchase the NFT.
+   * @param from the address to check for a reservation
+   * @param tokenId the ID of the NFT to check for a reserved offer
+   */
+  hasReservedOffer(
     from: string,
     tokenId: number | BN | string,
     txDetails?: Truffle.TransactionDetails
@@ -349,6 +334,17 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
       txDetails?: Truffle.TransactionDetails
     ): Promise<number>;
   };
+
+  /**
+   * Returns true if the given address is allowed to accept a sale of the given NFT. If no reservation is set on the sale, it means that anyone can buy the NFT.
+   * @param from the address to test for the permission to buy the NFT,
+   * @param tokenId the ID of the NFT to check for buy permission
+   */
+  isReservationOpenFor(
+    from: string,
+    tokenId: number | BN | string,
+    txDetails?: Truffle.TransactionDetails
+  ): Promise<boolean>;
 
   /**
    * Getter for the marketplace fees receiver address.
@@ -493,31 +489,35 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
   ): Promise<boolean>;
 
   /**
-   * Allow to update a sale for a given NFCHAMP ID at a given CHAMP wei price. Emits a {SaleUpdated} event. Requirements: - NFCHAMP ID should be on sale. - from can interact with the sale. - tokenWeiPrice should be strictly positive. - from must be the NFCHAMP owner. - msg.sender should be either the NFCHAMP owner or approved by the NFCHAMP owner. - ChampMarketplace contract should be approved for the given NFCHAMP ID.
+   * Allow to update a sale for a given NFCHAMP ID at a given CHAMP wei price. Emits a {SaleUpdated} event. Requirements: - NFCHAMP ID should be on sale. - from can interact with the sale. - tokenWeiPrice should be strictly positive. - reserve address must be different than from. - from must be the NFCHAMP owner. - msg.sender should be either the NFCHAMP owner or approved by the NFCHAMP owner. - ChampMarketplace contract should be approved for the given NFCHAMP ID.
    */
   updateSaleFrom: {
     (
       from: string,
       tokenId: number | BN | string,
       tokenWeiPrice: number | BN | string,
+      reserve: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<Truffle.TransactionResponse<AllEvents>>;
     call(
       from: string,
       tokenId: number | BN | string,
       tokenWeiPrice: number | BN | string,
+      reserve: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<void>;
     sendTransaction(
       from: string,
       tokenId: number | BN | string,
       tokenWeiPrice: number | BN | string,
+      reserve: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<string>;
     estimateGas(
       from: string,
       tokenId: number | BN | string,
       tokenWeiPrice: number | BN | string,
+      reserve: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<number>;
   };
@@ -553,36 +553,6 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
       weiPrice: number | BN | string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<{ 0: BN; 1: BN }>;
-
-    /**
-     * Allow to create a sale for a given NFCHAMP ID at a given CHAMP wei price. Emits a {SaleCreated} event. Requirements: - tokenWeiPrice should be strictly positive. - from must be the NFCHAMP owner. - msg.sender should be either the NFCHAMP owner or approved by the NFCHAMP owner. - ChampMarketplace contract should be approved for the given NFCHAMP ID. - NFCHAMP ID should not be on sale.
-     */
-    createSaleFrom: {
-      (
-        from: string,
-        tokenId: number | BN | string,
-        tokenWeiPrice: number | BN | string,
-        txDetails?: Truffle.TransactionDetails
-      ): Promise<Truffle.TransactionResponse<AllEvents>>;
-      call(
-        from: string,
-        tokenId: number | BN | string,
-        tokenWeiPrice: number | BN | string,
-        txDetails?: Truffle.TransactionDetails
-      ): Promise<void>;
-      sendTransaction(
-        from: string,
-        tokenId: number | BN | string,
-        tokenWeiPrice: number | BN | string,
-        txDetails?: Truffle.TransactionDetails
-      ): Promise<string>;
-      estimateGas(
-        from: string,
-        tokenId: number | BN | string,
-        tokenWeiPrice: number | BN | string,
-        txDetails?: Truffle.TransactionDetails
-      ): Promise<number>;
-    };
 
     /**
      * Allow to destroy a sale for a given NFCHAMP ID. Emits a {SaleDestroyed} event. Requirements: - NFCHAMP ID should be on sale. - from can interact with the sale. - from must be the NFCHAMP owner. - msg.sender should be either the NFCHAMP owner or approved by the NFCHAMP owner. - ChampMarketplace contract should be approved for the given NFCHAMP ID.
@@ -643,12 +613,12 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
     ): Promise<BN>;
 
     /**
-     * Returns the CHAMP wei price to buy a given NFCHAMP ID. If the sale does not exists, the function returns 0.
+     * Returns the CHAMP wei price to buy a given NFCHAMP ID and the address for which the sale is reserved. If the returned address is the 0 address, that means the sale is public. If the sale does not exists, the function returns a wei price of 0.
      */
     getSale(
       tokenId: number | BN | string,
       txDetails?: Truffle.TransactionDetails
-    ): Promise<BN>;
+    ): Promise<{ 0: BN; 1: string }>;
 
     /**
      * Grants `role` to `account`. If `account` had not been already granted `role`, emits a {RoleGranted} event. Requirements: - the caller must have ``role``'s admin role. May emit a {RoleGranted} event.
@@ -682,6 +652,17 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
      * @param tokenId the ID of the NFT to check for an option
      */
     hasOption(
+      from: string,
+      tokenId: number | BN | string,
+      txDetails?: Truffle.TransactionDetails
+    ): Promise<boolean>;
+
+    /**
+     * Returns true if the given address has a reserved offer on a sale of the specified NFT. If the sale is not reserved for a specific buyer, it means that anyone can purchase the NFT.
+     * @param from the address to check for a reservation
+     * @param tokenId the ID of the NFT to check for a reserved offer
+     */
+    hasReservedOffer(
       from: string,
       tokenId: number | BN | string,
       txDetails?: Truffle.TransactionDetails
@@ -726,6 +707,17 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
         txDetails?: Truffle.TransactionDetails
       ): Promise<number>;
     };
+
+    /**
+     * Returns true if the given address is allowed to accept a sale of the given NFT. If no reservation is set on the sale, it means that anyone can buy the NFT.
+     * @param from the address to test for the permission to buy the NFT,
+     * @param tokenId the ID of the NFT to check for buy permission
+     */
+    isReservationOpenFor(
+      from: string,
+      tokenId: number | BN | string,
+      txDetails?: Truffle.TransactionDetails
+    ): Promise<boolean>;
 
     /**
      * Getter for the marketplace fees receiver address.
@@ -870,31 +862,35 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
     ): Promise<boolean>;
 
     /**
-     * Allow to update a sale for a given NFCHAMP ID at a given CHAMP wei price. Emits a {SaleUpdated} event. Requirements: - NFCHAMP ID should be on sale. - from can interact with the sale. - tokenWeiPrice should be strictly positive. - from must be the NFCHAMP owner. - msg.sender should be either the NFCHAMP owner or approved by the NFCHAMP owner. - ChampMarketplace contract should be approved for the given NFCHAMP ID.
+     * Allow to update a sale for a given NFCHAMP ID at a given CHAMP wei price. Emits a {SaleUpdated} event. Requirements: - NFCHAMP ID should be on sale. - from can interact with the sale. - tokenWeiPrice should be strictly positive. - reserve address must be different than from. - from must be the NFCHAMP owner. - msg.sender should be either the NFCHAMP owner or approved by the NFCHAMP owner. - ChampMarketplace contract should be approved for the given NFCHAMP ID.
      */
     updateSaleFrom: {
       (
         from: string,
         tokenId: number | BN | string,
         tokenWeiPrice: number | BN | string,
+        reserve: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<Truffle.TransactionResponse<AllEvents>>;
       call(
         from: string,
         tokenId: number | BN | string,
         tokenWeiPrice: number | BN | string,
+        reserve: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<void>;
       sendTransaction(
         from: string,
         tokenId: number | BN | string,
         tokenWeiPrice: number | BN | string,
+        reserve: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<string>;
       estimateGas(
         from: string,
         tokenId: number | BN | string,
         tokenWeiPrice: number | BN | string,
+        reserve: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<number>;
     };
@@ -951,6 +947,70 @@ export interface TestChampMarketplaceInstance extends Truffle.ContractInstance {
         tokenId: number | BN | string,
         salePrice: number | BN | string,
         nftReceiver: string,
+        txDetails?: Truffle.TransactionDetails
+      ): Promise<number>;
+    };
+
+    /**
+     * See _createSaleFrom(address,uint64,uint256,address)
+     */
+    "createSaleFrom(address,uint64,uint256)": {
+      (
+        from: string,
+        tokenId: number | BN | string,
+        tokenWeiPrice: number | BN | string,
+        txDetails?: Truffle.TransactionDetails
+      ): Promise<Truffle.TransactionResponse<AllEvents>>;
+      call(
+        from: string,
+        tokenId: number | BN | string,
+        tokenWeiPrice: number | BN | string,
+        txDetails?: Truffle.TransactionDetails
+      ): Promise<void>;
+      sendTransaction(
+        from: string,
+        tokenId: number | BN | string,
+        tokenWeiPrice: number | BN | string,
+        txDetails?: Truffle.TransactionDetails
+      ): Promise<string>;
+      estimateGas(
+        from: string,
+        tokenId: number | BN | string,
+        tokenWeiPrice: number | BN | string,
+        txDetails?: Truffle.TransactionDetails
+      ): Promise<number>;
+    };
+
+    /**
+     * See _createSaleFrom(address,uint64,uint256,address)
+     */
+    "createSaleFrom(address,uint64,uint256,address)": {
+      (
+        from: string,
+        tokenId: number | BN | string,
+        tokenWeiPrice: number | BN | string,
+        reserve: string,
+        txDetails?: Truffle.TransactionDetails
+      ): Promise<Truffle.TransactionResponse<AllEvents>>;
+      call(
+        from: string,
+        tokenId: number | BN | string,
+        tokenWeiPrice: number | BN | string,
+        reserve: string,
+        txDetails?: Truffle.TransactionDetails
+      ): Promise<void>;
+      sendTransaction(
+        from: string,
+        tokenId: number | BN | string,
+        tokenWeiPrice: number | BN | string,
+        reserve: string,
+        txDetails?: Truffle.TransactionDetails
+      ): Promise<string>;
+      estimateGas(
+        from: string,
+        tokenId: number | BN | string,
+        tokenWeiPrice: number | BN | string,
+        reserve: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<number>;
     };


### PR DESCRIPTION
Allow for the creation of reserved offers through the ChampMarketplace contract.
Reserved offers introduce the concept of public and private sales. If set, a reserved offer ensures a sale can only be accepted by a specific wallet address. Otherwise, the sale is considered public and can be accepted by anyone.