### PR TITLE
Refundable CHAMP payments

### DIFF
--- a/contracts/layer-2/PaymentRelay.sol
+++ b/contracts/layer-2/PaymentRelay.sol
@@ -188,7 +188,7 @@ contract PaymentRelay is AccessControl {
         payment.state = PAYMENT_REFUNDED;
 
         IERC20 tokenContract = IERC20(payment.token);
-        tokenContract.safeTransferFrom(address(this), from, payment.amount);
+        tokenContract.safeTransfer(from, payment.amount);
 
         emit PaymentRefunded(UID, from, payment.token, payment.amount);
     }
@@ -228,11 +228,7 @@ contract PaymentRelay is AccessControl {
         payment.state = PAYMENT_EXECUTED;
 
         IERC20 tokenContract = IERC20(payment.token);
-        tokenContract.safeTransferFrom(
-            address(this),
-            forwardTo,
-            payment.amount
-        );
+        tokenContract.safeTransfer(forwardTo, payment.amount);
 
         emit PaymentSent(UID, from, payment.token, payment.amount);
     }

--- a/contracts/layer-2/PaymentRelay.sol
+++ b/contracts/layer-2/PaymentRelay.sol
@@ -58,10 +58,10 @@ contract PaymentRelay is AccessControl {
     function getPayment(bytes32 UID, address from)
         external
         view
-        returns (address, uint256)
+        returns (address, uint256, bool)
     {
         Payment memory payment = _getPayment(UID, from);
-        return (payment.token, payment.amount);
+        return (payment.token, payment.amount, payment.exec);
     }
 
     function _getPayment(bytes32 UID, address from)

--- a/contracts/layer-2/PaymentRelay.sol
+++ b/contracts/layer-2/PaymentRelay.sol
@@ -100,7 +100,7 @@ contract PaymentRelay is AccessControl {
     }
 
     /**
-     * @dev Function transfers `amount` of `token` from `from` to account the contract account.
+     * @dev Function transfers `amount` of `token` from `from` the contract account.
      * A new Payment instance holding payment details is assigned to `UID`.
      *
      * Payment is placed in PAYMENT_RESERVED state.
@@ -166,12 +166,12 @@ contract PaymentRelay is AccessControl {
      *
      * The payment is placed in PAYMENT_EXECUTED state.
      *
-     * The function caller must have REFUND_ROLE and not be `from`.
+     * The function caller must have OPERATOR_ROLE and not be `from`.
      *
      * Requirements:
      * - Payment to be refunded is currently reserved
      * - Function caller is not refund recipient
-     * - Function caller has REFUND_ROLE
+     * - Function caller has OPERATOR_ROLE
      */
     function refundPayment(address from, bytes32 UID) external {
         require(

--- a/contracts/layer-2/PaymentRelay.sol
+++ b/contracts/layer-2/PaymentRelay.sol
@@ -21,6 +21,7 @@ contract PaymentRelay is AccessControl {
     struct Payment {
         address token;
         uint256 amount;
+        bool exec;
     }
 
     // (keccak256 UID => payment) mapping of payments
@@ -40,13 +41,18 @@ contract PaymentRelay is AccessControl {
         return keccak256(abi.encodePacked(UID, from));
     }
 
+    function isPaymentReserved(bytes32 UID, address from) public view returns (bool) {
+        Payment memory payment = _getPayment(UID, from);
+        return payment.amount > 0 && !payment.exec;
+    }
+
     function isPaymentProcessed(bytes32 UID, address from)
         public
         view
         returns (bool)
     {
         Payment memory payment = _getPayment(UID, from);
-        return payment.amount > 0;
+        return payment.exec;
     }
 
     function getPayment(bytes32 UID, address from)
@@ -73,32 +79,48 @@ contract PaymentRelay is AccessControl {
         uint256 amount
     ) private {
         require(
-            !isPaymentProcessed(UID, from),
-            "PaymentRelay: Payment already processed"
+            !isPaymentReserved(UID, from) || !isPaymentProcessed(UID, from), 
+            "PaymentRelay: Payment already processed or reserved"
         );
 
-        _payments[getPaymentKey(UID, from)] = Payment(token, amount);
+        _payments[getPaymentKey(UID, from)] = Payment(token, amount, false);
     }
 
-    function execPayment(
+    function reservePayment(
         address tokenAddress,
         uint256 amount,
-        bytes32 UID,
-        address forwardTo
+        bytes32 UID
     ) external {
         _checkRole(TOKEN_ROLE, tokenAddress);
         require(
             amount > 0,
             "PaymentRelay: Payment amount should be strictly positive"
         );
-        _checkRole(RECEIVER_ROLE, forwardTo);
 
         _reservePayment(UID, msg.sender, tokenAddress, amount);
-        IERC20 tokenContract = IERC20(tokenAddress);
-        tokenContract.safeTransferFrom(msg.sender, forwardTo, amount);
 
-        emit PaymentSent(UID, msg.sender, tokenAddress, amount);
+        emit PaymentReserved(UID, msg.sender, tokenAddress, amount);
     }
 
+    function execPayment(
+        bytes32 UID,
+        address forwardTo
+    ) external {
+        require(
+            isPaymentReserved(UID, msg.sender),
+            "PaymentRelay: Payment reserve for message sender not found"
+        );
+        _checkRole(RECEIVER_ROLE, forwardTo);
+
+        Payment storage payment = _payments[getPaymentKey(UID, msg.sender)];
+        IERC20 tokenContract = IERC20(payment.token);
+        tokenContract.safeTransferFrom(msg.sender, forwardTo, payment.amount);
+
+        payment.exec = true;
+
+        emit PaymentSent(UID, msg.sender, payment.token, payment.amount);
+    }
+
+    event PaymentReserved(bytes32 UID, address from, address token, uint256 amount);
     event PaymentSent(bytes32 UID, address from, address token, uint256 amount);
 }

--- a/test/PaymentRelay.test.ts
+++ b/test/PaymentRelay.test.ts
@@ -33,7 +33,7 @@ contract("PaymentRelay", (accounts) => {
     );
   });
 
-  describe("As any user", function () {
+  describe.only("As any user", function () {
     const PAYMENT_UID = web3.utils.keccak256("PAYMENT_UID");
     const PAYMENT_UID_2 = web3.utils.keccak256("PAYMENT_UID_2");
     const ANY_UID = web3.utils.keccak256("ANY_UID");
@@ -72,9 +72,6 @@ contract("PaymentRelay", (accounts) => {
             await champContract.balanceOf(paymentRelayContract.address)
           ).toString()
         ).to.equals(amount);
-        expect((await champContract.balanceOf(sender)).toString()).to.equals(
-          amount
-        );
       });
 
       it("Should block duplicate payment reservation", async function () {
@@ -187,10 +184,6 @@ contract("PaymentRelay", (accounts) => {
             await champContract.balanceOf(paymentRelayContract.address)
           ).toString()
         ).to.equals("0");
-        // Since `amount` is half the sender's initial balance, we should expect the sender's balance to be equal to `amount` after payment execution
-        expect((await champContract.balanceOf(sender)).toString()).to.equals(
-          amount
-        );
       });
 
       it("Should mark payment as executed", async function () {
@@ -225,7 +218,12 @@ contract("PaymentRelay", (accounts) => {
     });
 
     describe("When payment is refunded", function () {
+      let balanceBeforeReserve: string;
+
       before(async function () {
+        balanceBeforeReserve = (
+          await champContract.balanceOf(sender)
+        ).toString();
         await champContract.approve(paymentRelayContract.address, amount, {
           from: sender,
         });
@@ -256,7 +254,7 @@ contract("PaymentRelay", (accounts) => {
 
       it("Should refund tokens back to the user", async function () {
         expect((await champContract.balanceOf(sender)).toString()).to.equals(
-          amount
+          balanceBeforeReserve
         );
         expect(
           (

--- a/types/truffle-contracts/IAccessControl.d.ts
+++ b/types/truffle-contracts/IAccessControl.d.ts
@@ -71,22 +71,22 @@ export interface IAccessControlInstance extends Truffle.ContractInstance {
    */
   grantRole: {
     (
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<Truffle.TransactionResponse<AllEvents>>;
     call(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<void>;
     sendTransaction(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<string>;
     estimateGas(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<number>;
@@ -167,22 +167,22 @@ export interface IAccessControlInstance extends Truffle.ContractInstance {
      */
     grantRole: {
       (
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<Truffle.TransactionResponse<AllEvents>>;
       call(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<void>;
       sendTransaction(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<string>;
       estimateGas(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<number>;

--- a/types/truffle-contracts/IAccessControlEnumerable.d.ts
+++ b/types/truffle-contracts/IAccessControlEnumerable.d.ts
@@ -65,22 +65,22 @@ export interface IAccessControlEnumerableInstance
    */
   grantRole: {
     (
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<Truffle.TransactionResponse<AllEvents>>;
     call(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<void>;
     sendTransaction(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<string>;
     estimateGas(
-      romle: string,
+      role: string,
       account: string,
       txDetails?: Truffle.TransactionDetails
     ): Promise<number>;
@@ -178,22 +178,22 @@ export interface IAccessControlEnumerableInstance
      */
     grantRole: {
       (
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<Truffle.TransactionResponse<AllEvents>>;
       call(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<void>;
       sendTransaction(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<string>;
       estimateGas(
-        romle: string,
+        role: string,
         account: string,
         txDetails?: Truffle.TransactionDetails
       ): Promise<number>;

--- a/types/truffle-contracts/PaymentRelay.d.ts
+++ b/types/truffle-contracts/PaymentRelay.d.ts
@@ -270,7 +270,7 @@ export interface PaymentRelayInstance extends Truffle.ContractInstance {
   };
 
   /**
-   * Function refunds a payment to `from`. Payment details are identified by `UID` and retrieved from storage. The payment is placed in PAYMENT_EXECUTED state. The function caller must have REFUND_ROLE and not be `from`. Requirements: - Payment to be refunded is currently reserved - Function caller is not refund recipient - Function caller has REFUND_ROLE
+   * Function refunds a payment to `from`. Payment details are identified by `UID` and retrieved from storage. The payment is placed in PAYMENT_EXECUTED state. The function caller must have OPERATOR_ROLE and not be `from`. Requirements: - Payment to be refunded is currently reserved - Function caller is not refund recipient - Function caller has OPERATOR_ROLE
    * Refunds an existing payment reservation. This operation can only be executed by an authorized operator. The payment owner can not refund their own payment reservation.
    */
   refundPayment: {
@@ -501,7 +501,7 @@ export interface PaymentRelayInstance extends Truffle.ContractInstance {
     };
 
     /**
-     * Function refunds a payment to `from`. Payment details are identified by `UID` and retrieved from storage. The payment is placed in PAYMENT_EXECUTED state. The function caller must have REFUND_ROLE and not be `from`. Requirements: - Payment to be refunded is currently reserved - Function caller is not refund recipient - Function caller has REFUND_ROLE
+     * Function refunds a payment to `from`. Payment details are identified by `UID` and retrieved from storage. The payment is placed in PAYMENT_EXECUTED state. The function caller must have OPERATOR_ROLE and not be `from`. Requirements: - Payment to be refunded is currently reserved - Function caller is not refund recipient - Function caller has OPERATOR_ROLE
      * Refunds an existing payment reservation. This operation can only be executed by an authorized operator. The payment owner can not refund their own payment reservation.
      */
     refundPayment: {


### PR DESCRIPTION
Enable the PaymentRelay contract to not only execute, but also refund payments.
To allow for this behaviour, a two-step payment process must be implemented. The first step is the payment reservation, where funds are put on escrow. The second and final step, is to either execute the payment (forward the funds to an authorized recipient), or refund the escrow funds back to the payment originator.